### PR TITLE
BaseFlywheelRewards

### DIFF
--- a/src/interfaces/IFlywheelRewards.sol
+++ b/src/interfaces/IFlywheelRewards.sol
@@ -2,10 +2,11 @@
 pragma solidity 0.8.10;
 
 import {ERC20} from "solmate/tokens/ERC20.sol";
+import {FlywheelCore} from "../FlywheelCore.sol";
 
 /**
  @title Rewards Module for Flywheel
- @notice The rewards module is a minimal interface for determining the quantity of rewards accrued to a flywheel market.
+ @notice The rewards module is a minimal interface for determining the quantity of rewards accrued to a flywheel strategy.
 
  Different module strategies include:
   * a static reward rate per second
@@ -14,5 +15,9 @@ import {ERC20} from "solmate/tokens/ERC20.sol";
   * liquid governance reward delegation
  */
 interface IFlywheelRewards {
-    function getAccruedRewards(ERC20 market, uint32 lastUpdatedTimestamp) external returns (uint256 rewards);
+    function getAccruedRewards(ERC20 strategy, uint32 lastUpdatedTimestamp) external returns (uint256 rewards);
+
+    function flywheel() external view returns(FlywheelCore);
+
+    function rewardToken() external view returns(ERC20); 
 }

--- a/src/rewards/BaseFlywheelRewards.sol
+++ b/src/rewards/BaseFlywheelRewards.sol
@@ -1,0 +1,36 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.10;
+
+import {SafeTransferLib, ERC20} from "solmate/utils/SafeTransferLib.sol";
+import {IFlywheelRewards} from "../interfaces/IFlywheelRewards.sol";
+import {FlywheelCore} from "../FlywheelCore.sol";
+
+/** 
+ @title Flywheel Reward Module
+ @notice Determines how many rewards accrue to each strategy globally over a given time period.
+*/ 
+abstract contract BaseFlywheelRewards is IFlywheelRewards {
+    using SafeTransferLib for ERC20;
+
+    /// @notice thrown when caller is not the flywheel
+    error FlywheelError();
+
+    /// @notice the reward token paid
+    ERC20 public immutable override rewardToken;
+
+    /// @notice the flywheel core contract
+    FlywheelCore public immutable override flywheel;
+
+    constructor(FlywheelCore _flywheel) {
+        flywheel = _flywheel;
+        ERC20 _rewardToken = _flywheel.rewardToken();
+        rewardToken = _rewardToken;
+
+        _rewardToken.safeApprove(address(_flywheel), type(uint256).max);
+    }
+
+    modifier onlyFlywheel {
+        if (msg.sender != address(flywheel)) revert FlywheelError();
+        _;
+    }
+}

--- a/src/rewards/FlywheelDynamicRewards.sol
+++ b/src/rewards/FlywheelDynamicRewards.sol
@@ -1,37 +1,25 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.10;
 
-import {SafeTransferLib, ERC20} from "solmate/utils/SafeTransferLib.sol";
-import {IFlywheelRewards} from "../interfaces/IFlywheelRewards.sol";
+import "./BaseFlywheelRewards.sol";
 
 /** 
  @title Flywheel Dynamic Reward Stream
- @notice Determines rewards based on how many reward tokens appeared in the market itself since last accrual.
+ @notice Determines rewards based on how many reward tokens appeared in the strategy itself since last accrual.
  All rewards are transferred atomically, so there is no need to use the last reward timestamp.
 */ 
-contract FlywheelDynamicRewards is IFlywheelRewards {
+contract FlywheelDynamicRewards is BaseFlywheelRewards {
     using SafeTransferLib for ERC20;
 
-    /// @notice the reward token paid
-    ERC20 public immutable rewardToken;
-
-    /// @notice the flywheel core contract
-    address public immutable flywheel;
-
-    constructor(ERC20 _rewardToken, address _flywheel) {
-        rewardToken = _rewardToken;
-        flywheel = _flywheel;
-        rewardToken.safeApprove(flywheel, type(uint256).max);
-    }
+    constructor(FlywheelCore _flywheel) BaseFlywheelRewards(_flywheel) {}
 
     /**
      @notice calculate and transfer accrued rewards to flywheel core
-     @param market the market to accrue rewards for
+     @param strategy the strategy to accrue rewards for
      @return amount the amount of tokens accrued and transferred
      */
-    function getAccruedRewards(ERC20 market, uint32) external override returns (uint256 amount) {
-        require(msg.sender == flywheel, "!flywheel");
-        amount = rewardToken.balanceOf(address(market));
-        if (amount > 0) rewardToken.safeTransferFrom(address(market), address(this), amount);
+    function getAccruedRewards(ERC20 strategy, uint32) external override onlyFlywheel returns (uint256 amount) {
+        amount = rewardToken.balanceOf(address(strategy));
+        if (amount > 0) rewardToken.safeTransferFrom(address(strategy), address(this), amount);
     }
 }

--- a/src/test/FlywheelStaticRewardsTest.t.sol
+++ b/src/test/FlywheelStaticRewardsTest.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.10;
 import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
 import {MockMarket} from "./mocks/MockMarket.sol";
+import {FlywheelCore} from "../FlywheelCore.sol";
 
 import {FlywheelStaticRewards, Authority} from "../rewards/FlywheelStaticRewards.sol";
 
@@ -12,14 +13,14 @@ contract FlywheelStaticRewardsTest is DSTestPlus {
     FlywheelStaticRewards rewards;
 
     MockMarket market;
-    MockERC20 rewardToken;
+    MockERC20 public rewardToken;
 
     function setUp() public {
         rewardToken = new MockERC20("test token", "TKN", 18);
 
         market = new MockMarket();
 
-        rewards = new FlywheelStaticRewards(rewardToken, address(this), address(this), Authority(address(0)));
+        rewards = new FlywheelStaticRewards(FlywheelCore(address(this)), address(this), Authority(address(0)));
     }
 
     function testSetRewardsInfo() public {

--- a/src/test/FlywheelTest.sol
+++ b/src/test/FlywheelTest.sol
@@ -32,7 +32,7 @@ contract FlywheelTest is DSTestPlus {
             Authority(address(0))
         );
 
-        rewards = new FlywheelDynamicRewards(rewardToken, address(flywheel));
+        rewards = new FlywheelDynamicRewards(flywheel);
 
         flywheel.setFlywheelRewards(rewards);
     }
@@ -220,7 +220,7 @@ contract FlywheelTest is DSTestPlus {
             Authority(address(0))
         );
 
-        rewards = new FlywheelDynamicRewards(rewardToken, address(flywheel));
+        rewards = new FlywheelDynamicRewards(flywheel);
 
         flywheel.setFlywheelRewards(rewards);
 

--- a/src/test/Integration.t.sol
+++ b/src/test/Integration.t.sol
@@ -50,7 +50,7 @@ contract FlywheelIntegrationTest is DSTestPlus {
             Authority(address(0))
         );
 
-        rewards = new FlywheelStaticRewards(rewardToken, address(flywheel), address(this), Authority(address(0)));
+        rewards = new FlywheelStaticRewards(flywheel, address(this), Authority(address(0)));
 
         flywheel.setFlywheelRewards(rewards);
         


### PR DESCRIPTION
Add a baseFlywheelRewards abstract class which creates a default constructor that approves the flywheel for rewardToken and adds the `onlyFlywheel` modifier