### PR TITLE
Init strategy rewards

### DIFF
--- a/src/FlywheelCore.sol
+++ b/src/FlywheelCore.sol
@@ -139,8 +139,11 @@ contract FlywheelCore is Auth {
     event AddStrategy(address indexed newStrategy);
 
     /// @notice initialize a new strategy
-    function addStrategyForRewards(ERC20 strategy) external requiresAuth {
+    function addStrategyForRewards(ERC20 strategy, bytes memory data) external requiresAuth {
         _addStrategyForRewards(strategy);
+
+        // initialize the rewards state
+        flywheelRewards.initializeStrategy(strategy, data);
     }
 
     function _addStrategyForRewards(ERC20 strategy) internal {

--- a/src/interfaces/IFlywheelRewards.sol
+++ b/src/interfaces/IFlywheelRewards.sol
@@ -32,6 +32,11 @@ interface IFlywheelRewards {
     */
     function getAccruedRewards(ERC20 strategy, uint32 lastUpdatedTimestamp) external returns (uint256 rewards);
 
+    /**
+     @notice initialize the state of the strategy with external data
+     @param strategy the strategy to initialize
+     @param data arbitrary data that is abi.encode()-ed
+    */
     function initializeStrategy(ERC20 strategy, bytes memory data) external;
 
     /// @notice return the flywheel core address

--- a/src/interfaces/IFlywheelRewards.sol
+++ b/src/interfaces/IFlywheelRewards.sol
@@ -32,6 +32,8 @@ interface IFlywheelRewards {
     */
     function getAccruedRewards(ERC20 strategy, uint32 lastUpdatedTimestamp) external returns (uint256 rewards);
 
+    function initializeStrategy(ERC20 strategy, bytes memory data) external;
+
     /// @notice return the flywheel core address
     function flywheel() external view returns (FlywheelCore);
 

--- a/src/rewards/FlywheelDynamicRewards.sol
+++ b/src/rewards/FlywheelDynamicRewards.sol
@@ -32,6 +32,10 @@ abstract contract FlywheelDynamicRewards is BaseFlywheelRewards {
         rewardsCycleLength = _rewardsCycleLength;
     }
 
+    /**
+     @notice initialize the state of the strategy with external data
+     @param strategy the strategy to initialize
+        */
     function initializeStrategy(ERC20 strategy, bytes memory) external onlyFlywheel {
         uint192 rewards = getNextCycleRewards(strategy);
         uint32 timestamp = block.timestamp.safeCastTo32();

--- a/src/rewards/FlywheelDynamicRewards.sol
+++ b/src/rewards/FlywheelDynamicRewards.sol
@@ -32,6 +32,15 @@ abstract contract FlywheelDynamicRewards is BaseFlywheelRewards {
         rewardsCycleLength = _rewardsCycleLength;
     }
 
+    function initializeStrategy(ERC20 strategy, bytes memory) external onlyFlywheel {
+        uint192 rewards = getNextCycleRewards(strategy);
+        uint32 timestamp = block.timestamp.safeCastTo32();
+        uint32 end = ((timestamp + rewardsCycleLength) / rewardsCycleLength) * rewardsCycleLength;
+
+        rewardsCycle[strategy] = RewardsCycle({start: timestamp, end: end, reward: rewards});
+        emit NewRewardsCycle(timestamp, end, rewards);
+    }
+
     /**
      @notice calculate and transfer accrued rewards to flywheel core
      @param strategy the strategy to accrue rewards for

--- a/src/rewards/FlywheelGaugeRewards.sol
+++ b/src/rewards/FlywheelGaugeRewards.sol
@@ -209,7 +209,7 @@ contract FlywheelGaugeRewards is Auth, BaseFlywheelRewards {
         }
     }
 
-    function initializeStrategy(ERC20 strategy, bytes memory data) external onlyFlywheel {
+    function initializeStrategy(ERC20 gauge, bytes memory) external onlyFlywheel {
         gaugeQueuedRewards[gauge] = QueuedRewards({
             priorCycleRewards: 0,
             cycleRewards: 0,

--- a/src/rewards/FlywheelGaugeRewards.sol
+++ b/src/rewards/FlywheelGaugeRewards.sol
@@ -209,6 +209,14 @@ contract FlywheelGaugeRewards is Auth, BaseFlywheelRewards {
         }
     }
 
+    function initializeStrategy(ERC20 strategy, bytes memory data) external onlyFlywheel {
+        gaugeQueuedRewards[gauge] = QueuedRewards({
+            priorCycleRewards: 0,
+            cycleRewards: 0,
+            storedCycle: 0
+        });
+    }
+
     /**
      @notice calculate and transfer accrued rewards to flywheel core
      @param gauge the gauge to accrue rewards for

--- a/src/rewards/FlywheelGaugeRewards.sol
+++ b/src/rewards/FlywheelGaugeRewards.sol
@@ -209,6 +209,10 @@ contract FlywheelGaugeRewards is Auth, BaseFlywheelRewards {
         }
     }
 
+    /**
+     @notice initialize the state of the strategy with external data
+     @param gauge the strategy to initialize
+    */
     function initializeStrategy(ERC20 gauge, bytes memory) external onlyFlywheel {
         gaugeQueuedRewards[gauge] = QueuedRewards({
             priorCycleRewards: 0,

--- a/src/rewards/FlywheelStaticRewards.sol
+++ b/src/rewards/FlywheelStaticRewards.sol
@@ -24,18 +24,14 @@ contract FlywheelStaticRewards is BaseFlywheelRewards {
     constructor(FlywheelCore _flywheel) BaseFlywheelRewards(_flywheel) {}
 
     /**
-     @notice set rewards per second and rewards end time for Fei Rewards
-     @param strategy the strategy to accrue rewards for
-     @param rewards the rewards info for the strategy
-     */
-    function setRewardsInfo(ERC20 strategy, RewardsInfo calldata rewards) external requiresAuth {
-        rewardsInfo[strategy] = rewards;
-        emit RewardsInfoUpdate(strategy, rewards.rewardsPerSecond, rewards.rewardsEndTimestamp);
-    }
-
+     @notice initialize the state of the strategy with external data
+     @param strategy the strategy to initialize
+     @param data arbitrary data that is abi.encode()-ed
+    */
     function initializeStrategy(ERC20 strategy, bytes memory data) external onlyFlywheel {
         RewardsInfo memory rewards = abi.decode(data, (RewardsInfo));
-        setRewardsInfo(strategy, rewards);
+        rewardsInfo[strategy] = rewards;
+        emit RewardsInfoUpdate(strategy, rewards.rewardsPerSecond, rewards.rewardsEndTimestamp);
     }
 
     /**

--- a/src/rewards/FlywheelStaticRewards.sol
+++ b/src/rewards/FlywheelStaticRewards.sol
@@ -23,21 +23,19 @@ contract FlywheelStaticRewards is BaseFlywheelRewards {
 
     constructor(FlywheelCore _flywheel) BaseFlywheelRewards(_flywheel) {}
 
-//    /**
-//     @notice set rewards per second and rewards end time for Fei Rewards
-//     @param strategy the strategy to accrue rewards for
-//     @param rewards the rewards info for the strategy
-//     */
-//    function setRewardsInfo(ERC20 strategy, RewardsInfo calldata rewards) external requiresAuth {
-//        rewardsInfo[strategy] = rewards;
-//        emit RewardsInfoUpdate(strategy, rewards.rewardsPerSecond, rewards.rewardsEndTimestamp);
-//    }
-
-    // TODO replace setRewardsInfo
-    function initializeStrategy(ERC20 strategy, bytes memory data) external onlyFlywheel {
-        RewardsInfo memory rewards = abi.decode(data, (RewardsInfo));
+    /**
+     @notice set rewards per second and rewards end time for Fei Rewards
+     @param strategy the strategy to accrue rewards for
+     @param rewards the rewards info for the strategy
+     */
+    function setRewardsInfo(ERC20 strategy, RewardsInfo calldata rewards) external requiresAuth {
         rewardsInfo[strategy] = rewards;
         emit RewardsInfoUpdate(strategy, rewards.rewardsPerSecond, rewards.rewardsEndTimestamp);
+    }
+
+    function initializeStrategy(ERC20 strategy, bytes memory data) external onlyFlywheel {
+        RewardsInfo memory rewards = abi.decode(data, (RewardsInfo));
+        setRewardsInfo(strategy, rewards);
     }
 
     /**

--- a/src/rewards/FlywheelStaticRewards.sol
+++ b/src/rewards/FlywheelStaticRewards.sol
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 pragma solidity 0.8.10;
 
-import {Auth, Authority} from "solmate/auth/Auth.sol";
 import "./BaseFlywheelRewards.sol";
 
 /** 
  @title Flywheel Static Reward Stream
  @notice Determines rewards per strategy based on a fixed reward rate per second
 */
-contract FlywheelStaticRewards is Auth, BaseFlywheelRewards {
+contract FlywheelStaticRewards is BaseFlywheelRewards {
     event RewardsInfoUpdate(ERC20 indexed strategy, uint224 rewardsPerSecond, uint32 rewardsEndTimestamp);
 
     struct RewardsInfo {
@@ -22,18 +21,21 @@ contract FlywheelStaticRewards is Auth, BaseFlywheelRewards {
     /// @notice rewards info per strategy
     mapping(ERC20 => RewardsInfo) public rewardsInfo;
 
-    constructor(
-        FlywheelCore _flywheel,
-        address _owner,
-        Authority _authority
-    ) Auth(_owner, _authority) BaseFlywheelRewards(_flywheel) {}
+    constructor(FlywheelCore _flywheel) BaseFlywheelRewards(_flywheel) {}
 
-    /**
-     @notice set rewards per second and rewards end time for Fei Rewards
-     @param strategy the strategy to accrue rewards for
-     @param rewards the rewards info for the strategy
-     */
-    function setRewardsInfo(ERC20 strategy, RewardsInfo calldata rewards) external requiresAuth {
+//    /**
+//     @notice set rewards per second and rewards end time for Fei Rewards
+//     @param strategy the strategy to accrue rewards for
+//     @param rewards the rewards info for the strategy
+//     */
+//    function setRewardsInfo(ERC20 strategy, RewardsInfo calldata rewards) external requiresAuth {
+//        rewardsInfo[strategy] = rewards;
+//        emit RewardsInfoUpdate(strategy, rewards.rewardsPerSecond, rewards.rewardsEndTimestamp);
+//    }
+
+    // TODO replace setRewardsInfo
+    function initializeStrategy(ERC20 strategy, bytes memory data) external onlyFlywheel {
+        RewardsInfo memory rewards = abi.decode(data, (RewardsInfo));
         rewardsInfo[strategy] = rewards;
         emit RewardsInfoUpdate(strategy, rewards.rewardsPerSecond, rewards.rewardsEndTimestamp);
     }

--- a/src/test/FlywheelTest.sol
+++ b/src/test/FlywheelTest.sol
@@ -40,7 +40,7 @@ contract FlywheelTest is DSTestPlus {
     }
 
     function testAddStrategy(ERC20 strat) public {
-        flywheel.addStrategyForRewards(strat);
+        flywheel.addStrategyForRewards(strat, "");
         (uint224 index, uint32 timestamp) = flywheel.strategyState(strat);
         require(index == flywheel.ONE());
         require(timestamp == block.timestamp);
@@ -48,7 +48,7 @@ contract FlywheelTest is DSTestPlus {
 
     function testFailAddStrategy() public {
         hevm.prank(address(1));
-        flywheel.addStrategyForRewards(strategy);
+        flywheel.addStrategyForRewards(strategy, "");
     }
 
     function testSetFlywheelRewards(uint256 mintAmount) public {
@@ -91,7 +91,7 @@ contract FlywheelTest is DSTestPlus {
         rewardToken.mint(address(rewards), rewardAmount);
         rewards.setRewardsAmount(strategy, rewardAmount);
 
-        flywheel.addStrategyForRewards(strategy);
+        flywheel.addStrategyForRewards(strategy, "");
 
         uint256 accrued = flywheel.accrue(strategy, user);
 
@@ -121,7 +121,7 @@ contract FlywheelTest is DSTestPlus {
         rewardToken.mint(address(rewards), rewardAmount);
         rewards.setRewardsAmount(strategy, rewardAmount);
 
-        flywheel.addStrategyForRewards(strategy);
+        flywheel.addStrategyForRewards(strategy, "");
 
         (uint256 accrued1, uint256 accrued2) = flywheel.accrue(strategy, user, user2);
 
@@ -169,7 +169,7 @@ contract FlywheelTest is DSTestPlus {
         rewardToken.mint(address(rewards), 10 ether);
         rewards.setRewardsAmount(strategy, 10 ether);
 
-        flywheel.addStrategyForRewards(strategy);
+        flywheel.addStrategyForRewards(strategy, "");
 
         uint256 accrued = flywheel.accrue(strategy, user);
 
@@ -195,7 +195,7 @@ contract FlywheelTest is DSTestPlus {
         rewardToken.mint(address(rewards), 10 ether);
         rewards.setRewardsAmount(strategy, 10 ether);
 
-        flywheel.addStrategyForRewards(strategy);
+        flywheel.addStrategyForRewards(strategy, "");
 
         (uint256 accrued, uint256 accrued2) = flywheel.accrue(strategy, user, user2);
 
@@ -267,7 +267,7 @@ contract FlywheelTest is DSTestPlus {
         rewardToken.mint(address(rewards), rewardAmount);
         rewards.setRewardsAmount(strategy, rewardAmount);
 
-        flywheel.addStrategyForRewards(strategy);
+        flywheel.addStrategyForRewards(strategy, "");
 
         uint256 accrued = flywheel.accrue(strategy, user);
 

--- a/src/test/mocks/MockRewards.sol
+++ b/src/test/mocks/MockRewards.sol
@@ -16,4 +16,8 @@ contract MockRewards is BaseFlywheelRewards {
     function getAccruedRewards(ERC20 strategy, uint32) external view override onlyFlywheel returns (uint256 amount) {
         return rewardsAmount[strategy];
     }
+
+    function initializeStrategy(ERC20 strategy, bytes calldata data) external onlyFlywheel {
+
+    }
 }

--- a/src/test/rewards/FlywheelStaticRewardsTest.t.sol
+++ b/src/test/rewards/FlywheelStaticRewardsTest.t.sol
@@ -5,7 +5,7 @@ import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
 import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
 import {FlywheelCore} from "../../FlywheelCore.sol";
 
-import {FlywheelStaticRewards, Authority} from "../../rewards/FlywheelStaticRewards.sol";
+import {FlywheelStaticRewards} from "../../rewards/FlywheelStaticRewards.sol";
 
 contract FlywheelStaticRewardsTest is DSTestPlus {
     FlywheelStaticRewards rewards;
@@ -18,18 +18,18 @@ contract FlywheelStaticRewardsTest is DSTestPlus {
 
         strategy = new MockERC20("test strategy", "TKN", 18);
 
-        rewards = new FlywheelStaticRewards(FlywheelCore(address(this)), address(this), Authority(address(0)));
+        rewards = new FlywheelStaticRewards(FlywheelCore(address(this)));
     }
 
-    function testSetRewardsInfo() public {
+    function testInitializeStrategy() public {
         (uint224 rewardsPerSecond, uint32 rewardsEndTimestamp) = rewards.rewardsInfo(strategy);
         require(rewardsPerSecond == 0);
         require(rewardsEndTimestamp == 0);
 
         uint32 newEnd = uint32(block.timestamp) + 100;
-        rewards.setRewardsInfo(
+        rewards.initializeStrategy(
             strategy,
-            FlywheelStaticRewards.RewardsInfo({rewardsPerSecond: 1 ether, rewardsEndTimestamp: newEnd})
+            abi.encode(FlywheelStaticRewards.RewardsInfo({rewardsPerSecond: 1 ether, rewardsEndTimestamp: newEnd}))
         );
 
         (rewardsPerSecond, rewardsEndTimestamp) = rewards.rewardsInfo(strategy);
@@ -40,7 +40,7 @@ contract FlywheelStaticRewardsTest is DSTestPlus {
 
     function testGetAccruedRewards() public {
         hevm.warp(1000);
-        testSetRewardsInfo();
+        testInitializeStrategy();
 
         rewardToken.mint(address(rewards), 100 ether);
 
@@ -50,7 +50,7 @@ contract FlywheelStaticRewardsTest is DSTestPlus {
 
     function testGetAccruedRewardsAfterEnd() public {
         hevm.warp(1000);
-        testSetRewardsInfo();
+        testInitializeStrategy();
         hevm.warp(2000);
 
         rewardToken.mint(address(rewards), 100 ether);
@@ -61,7 +61,7 @@ contract FlywheelStaticRewardsTest is DSTestPlus {
 
     function testGetAccruedRewardsCappedAfterEnd() public {
         hevm.warp(1000);
-        testSetRewardsInfo();
+        testInitializeStrategy();
         hevm.warp(2000);
 
         rewardToken.mint(address(rewards), 20 ether);


### PR DESCRIPTION
Static/dynamic/gauges rewards should have an initialization function that initializes theirs state. This way, the subsequent calls to `accrue`/`claimRewards` will be successful from the first call.