### PR TITLE
Audit Fixes

### DIFF
--- a/src/test/token/ERC20MultiVotes.t.sol
+++ b/src/test/token/ERC20MultiVotes.t.sol
@@ -164,11 +164,15 @@ contract ERC20MultiVotesTest is DSTestPlus {
         token.delegate(oldDelegatee, beforeDelegateAmount);
 
         token.delegate(newDelegatee);
+
+        uint256 expected = newDelegatee == address(0) ? 0 : mintAmount;
+        uint256 expectedFree = newDelegatee == address(0) ? mintAmount : 0;
+
         require(oldDelegatee == newDelegatee || token.delegatesVotesCount(address(this), oldDelegatee) == 0);
-        require(token.delegatesVotesCount(address(this), newDelegatee) == mintAmount);
-        require(token.userDelegatedVotes(address(this)) == mintAmount);
-        require(token.getVotes(newDelegatee) == mintAmount);
-        require(token.freeVotes(address(this)) == 0);
+        require(token.delegatesVotesCount(address(this), newDelegatee) == expected);
+        require(token.userDelegatedVotes(address(this)) == expected);
+        require(token.getVotes(newDelegatee) == expected);
+        require(token.freeVotes(address(this)) == expectedFree);
     }
 
     function testBackwardCompatibleDelegateBySig(
@@ -203,12 +207,15 @@ contract ERC20MultiVotesTest is DSTestPlus {
             )
         );
 
+        uint256 expected = newDelegatee == address(0) ? 0 : mintAmount;
+        uint256 expectedFree = newDelegatee == address(0) ? mintAmount : 0;
+
         token.delegateBySig(newDelegatee, 0, block.timestamp, v, r, s);
         require(oldDelegatee == newDelegatee || token.delegatesVotesCount(owner, oldDelegatee) == 0);
-        require(token.delegatesVotesCount(owner, newDelegatee) == mintAmount);
-        require(token.userDelegatedVotes(owner) == mintAmount);
-        require(token.getVotes(newDelegatee) == mintAmount);
-        require(token.freeVotes(owner) == 0);
+        require(token.delegatesVotesCount(owner, newDelegatee) == expected);
+        require(token.userDelegatedVotes(owner) == expected);
+        require(token.getVotes(newDelegatee) == expected);
+        require(token.freeVotes(owner) == expectedFree);
     }
 
     /*///////////////////////////////////////////////////////////////

--- a/src/token/ERC20Gauges.sol
+++ b/src/token/ERC20Gauges.sol
@@ -141,7 +141,7 @@ abstract contract ERC20Gauges is ERC20, Auth {
 
     /// @notice returns true if `gauge` is not in deprecated gauges
     function isGauge(address gauge) external view returns (bool) {
-        return !_deprecatedGauges.contains(gauge);
+        return _gauges.contains(gauge) && !_deprecatedGauges.contains(gauge);
     }
 
     /// @notice returns the number of live gauges

--- a/src/token/ERC20MultiVotes.sol
+++ b/src/token/ERC20MultiVotes.sol
@@ -256,7 +256,7 @@ abstract contract ERC20MultiVotes is ERC20, Auth {
         uint256 newDelegates = _delegatesVotesCount[delegator][delegatee] - amount;
 
         if (newDelegates == 0) {
-            assert(_delegates[delegator].remove(delegatee)); // Should never fail.
+            require(_delegates[delegator].remove(delegatee));
         }
 
         _delegatesVotesCount[delegator][delegatee] = newDelegates;
@@ -342,7 +342,7 @@ abstract contract ERC20MultiVotes is ERC20, Auth {
             if (delegateVotes != 0) {
                 totalFreed += delegateVotes;
 
-                assert(_delegates[user].remove(delegatee)); // Remove from set. Should never fail.
+                require(_delegates[user].remove(delegatee)); // Remove from set. Should never fail.
 
                 _delegatesVotesCount[user][delegatee] = 0;
 
@@ -383,6 +383,7 @@ abstract contract ERC20MultiVotes is ERC20, Auth {
             s
         );
         require(nonce == nonces[signer]++, "ERC20MultiVotes: invalid nonce");
+        require(signer != address(0));
         _delegate(signer, delegatee);
     }
 }


### PR DESCRIPTION
The major issues in the audit report revolved around gauges being removed and added back causing discrepancies in the FlywheelGaugeRewards accounting. 

The implemented fix is different from what was proposed, and instead makes the `gauges` array append-only, so they must always be a part of flywheelGaugeReward cycles even if deprecated. Instead, when deprecated they just return 0.

