### PR TITLE
Proportional rewards / FEI Savings Rate

### DIFF
--- a/src/rewards/FlywheelProportionalRewards.sol
+++ b/src/rewards/FlywheelProportionalRewards.sol
@@ -65,6 +65,6 @@ contract FlywheelProportionalRewards is Auth, BaseFlywheelRewards {
             elapsed = rewards.rewardsEndTimestamp - lastUpdatedTimestamp;
         }
 
-        amount = rewards.rewardBasisPointsPerYear * ((vault.totalAssets() * elapsed) / 365.25 days);
+        amount = (rewards.rewardBasisPointsPerYear * ((vault.totalAssets() * elapsed) / 365.25 days)) / 10_000;
     }
 }

--- a/src/rewards/FlywheelProportionalRewards.sol
+++ b/src/rewards/FlywheelProportionalRewards.sol
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.10;
+
+import {Auth, Authority} from "solmate/auth/Auth.sol";
+import {ERC4626} from "solmate/mixins/ERC4626.sol";
+import "./BaseFlywheelRewards.sol";
+
+/** 
+ @title Flywheel Proportional Reward Stream
+ @notice Determines rewards per strategy based off of a fixed reward percentage per year (ie, an apr)   
+         Uses an underlying ERC4626 vault's totalAssets() to determine the amount of tokens to reward.
+ **/
+contract FlywheelProportionalRewards is Auth, BaseFlywheelRewards {
+    event RewardsInfoUpdate(ERC20 indexed strategy, uint224 rewardBasisPointsPerYear, uint32 rewardsEndTimestamp);
+
+    struct RewardsInfo {
+        /// @notice ERC4626 vault to use for calculating rewards
+        address vault;
+        /// @notice Reward bips per year
+        uint224 rewardBasisPointsPerYear;
+        /// @notice The timestamp the rewards end at
+        /// @dev use 0 to specify no end
+        uint32 rewardsEndTimestamp;
+    }
+
+    /// @notice rewards info per strategy
+    mapping(ERC20 => RewardsInfo) public rewardsInfo;
+
+    constructor(
+        FlywheelCore _flywheel,
+        address _owner,
+        Authority _authority
+    ) Auth(_owner, _authority) BaseFlywheelRewards(_flywheel) {}
+
+    /**
+     @notice set reward basis points per year for a strategy
+     @param strategy the strategy to accrue rewards for
+     @param rewards the rewards info for the strategy
+     */
+    function setRewardsInfo(ERC20 strategy, RewardsInfo calldata rewards) external requiresAuth {
+        rewardsInfo[strategy] = rewards;
+        emit RewardsInfoUpdate(strategy, rewards.rewardBasisPointsPerYear, rewards.rewardsEndTimestamp);
+    }
+
+    /**
+     @notice calculate and transfer accrued rewards to flywheel core
+     @param strategy the strategy to accrue rewards for
+     @param lastUpdatedTimestamp the last updated time for strategy
+     @return amount the amount of tokens accrued and transferred
+     */
+    function getAccruedRewards(ERC20 strategy, uint32 lastUpdatedTimestamp)
+        external
+        view
+        override
+        onlyFlywheel
+        returns (uint256 amount)
+    {
+        RewardsInfo memory rewards = rewardsInfo[strategy];
+        ERC4626 vault = ERC4626(rewards.vault);
+
+        uint256 elapsed;
+        if (rewards.rewardsEndTimestamp == 0 || rewards.rewardsEndTimestamp > block.timestamp) {
+            elapsed = block.timestamp - lastUpdatedTimestamp;
+        } else if (rewards.rewardsEndTimestamp > lastUpdatedTimestamp) {
+            elapsed = rewards.rewardsEndTimestamp - lastUpdatedTimestamp;
+        }
+
+        amount = rewards.rewardBasisPointsPerYear * ((vault.totalAssets() * elapsed) / 365.25 days);
+    }
+}

--- a/src/test/FlywheelTest.sol
+++ b/src/test/FlywheelTest.sol
@@ -26,15 +26,15 @@ contract FlywheelTest is DSTestPlus {
 
         booster = new MockBooster();
 
+        rewards = new MockRewards(flywheel);
+
         flywheel = new FlywheelCore(
             rewardToken,
-            MockRewards(address(0)),
-            IFlywheelBooster(address(0)),
+            rewards,
+            IFlywheelBooster(address(booster)),
             address(this),
             Authority(address(0))
         );
-
-        rewards = new MockRewards(flywheel);
 
         flywheel.setFlywheelRewards(rewards);
     }

--- a/src/test/FlywheelTest.sol
+++ b/src/test/FlywheelTest.sol
@@ -30,8 +30,8 @@ contract FlywheelTest is DSTestPlus {
 
         flywheel = new FlywheelCore(
             rewardToken,
-            rewards,
-            IFlywheelBooster(address(booster)),
+            MockRewards(address(0)),
+            IFlywheelBooster(address(0)),
             address(this),
             Authority(address(0))
         );

--- a/src/test/FlywheelTest.sol
+++ b/src/test/FlywheelTest.sol
@@ -26,8 +26,6 @@ contract FlywheelTest is DSTestPlus {
 
         booster = new MockBooster();
 
-        rewards = new MockRewards(flywheel);
-
         flywheel = new FlywheelCore(
             rewardToken,
             MockRewards(address(0)),
@@ -35,6 +33,8 @@ contract FlywheelTest is DSTestPlus {
             address(this),
             Authority(address(0))
         );
+
+        rewards = new MockRewards(flywheel);
 
         flywheel.setFlywheelRewards(rewards);
     }

--- a/src/test/rewards/FlywheelProportionalRewardsTest.t.sol
+++ b/src/test/rewards/FlywheelProportionalRewardsTest.t.sol
@@ -1,0 +1,73 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+pragma solidity 0.8.10;
+
+import {DSTestPlus} from "solmate/test/utils/DSTestPlus.sol";
+import {MockERC20} from "solmate/test/utils/mocks/MockERC20.sol";
+import {MockERC4626} from "solmate/test/utils/mocks/MockERC4626.sol";
+import {FlywheelCore, IFlywheelBooster, IFlywheelRewards} from "../../FlywheelCore.sol";
+import {MockBooster} from "../mocks/MockBooster.sol";
+import {MockRewards} from "../mocks/MockRewards.sol";
+
+import {FlywheelProportionalRewards, Authority} from "../../rewards/FlywheelProportionalRewards.sol";
+
+contract FlywheelProportionalRewardsTest is DSTestPlus {
+    FlywheelProportionalRewards rewards;
+
+    MockERC20 strategy;
+    MockERC20 public rewardToken;
+    MockERC4626 public vault;
+    FlywheelCore public flywheel;
+
+    function setUp() public {
+        rewardToken = new MockERC20("test token", "TKN", 18);
+
+        strategy = new MockERC20("test strategy", "TKN", 18);
+
+        vault = new MockERC4626(rewardToken, "TestFeiSavingsRate", "TFSR");
+
+        flywheel = new FlywheelCore(
+            rewardToken,
+            MockRewards(address(0)),
+            IFlywheelBooster(address(0)),
+            address(this),
+            Authority(address(0))
+        );
+
+        rewards = new FlywheelProportionalRewards(FlywheelCore(address(this)), address(this), Authority(address(0)));
+    }
+
+    function setRewardsInfo() public {
+        (, uint224 rewardsBasisPointsPerYear, uint32 rewardsEndTimestamp) = rewards.rewardsInfo(strategy);
+        require(rewardsBasisPointsPerYear == 0);
+        require(rewardsEndTimestamp == 0);
+
+        rewards.setRewardsInfo(
+            strategy,
+            FlywheelProportionalRewards.RewardsInfo({
+                vault: address(vault),
+                rewardBasisPointsPerYear: 10_000,
+                rewardsEndTimestamp: 0
+            })
+        );
+    }
+
+    function testGetAccruedRewards() public {
+        setRewardsInfo();
+
+        address alice = address(0xABCD);
+        rewardToken.mint(alice, 100 ether);
+        hevm.prank(alice);
+        rewardToken.approve(address(vault), 100 ether);
+        hevm.prank(alice);
+        vault.deposit(100 ether, alice);
+
+        flywheel.accrue(strategy, alice);
+
+        hevm.warp(365.25 days); // 1 year in seconds;
+
+        flywheel.accrue(strategy, alice);
+
+        // After exactly one year at 100% APR, we should have exactly our starting balance in rewards!
+        assertEq(rewards.getAccruedRewards(strategy, uint32(block.timestamp - 365.25 days)), 100 ether);
+    }
+}


### PR DESCRIPTION
Implements a proportional rewards stream which determines rewards per strategy based off of a fixed reward percentage per year (ie, an apr). Uses an underlying ERC4626 vault's totalAssets() function to determine the amount of tokens to reward.