### PR TITLE
Transfer balance from old the FlywheelRewards only if it's not the zero address

### DIFF
--- a/src/FlywheelCore.sol
+++ b/src/FlywheelCore.sol
@@ -40,6 +40,8 @@ contract FlywheelCore is Auth {
     /// @notice optional booster module for calculating virtual balances on strategies
     IFlywheelBooster public flywheelBooster;
 
+    error InvalidAddress();
+
     constructor(
         ERC20 _rewardToken,
         IFlywheelRewards _flywheelRewards,
@@ -163,6 +165,7 @@ contract FlywheelCore is Auth {
 
     /// @notice swap out the flywheel rewards contract
     function setFlywheelRewards(IFlywheelRewards newFlywheelRewards) external requiresAuth {
+        if (address(newFlywheelRewards) == address(0)) revert InvalidAddress();
         if (address(flywheelRewards) != address(0)) {
             uint256 oldRewardBalance = rewardToken.balanceOf(address(flywheelRewards));
 

--- a/src/FlywheelCore.sol
+++ b/src/FlywheelCore.sol
@@ -164,7 +164,7 @@ contract FlywheelCore is Auth {
     /// @notice swap out the flywheel rewards contract
     function setFlywheelRewards(IFlywheelRewards newFlywheelRewards) external requiresAuth {
         uint256 oldRewardBalance = rewardToken.balanceOf(address(flywheelRewards));
-        if (oldRewardBalance > 0) {
+        if (address(flywheelRewards) != address(0) && oldRewardBalance > 0) {
             rewardToken.safeTransferFrom(address(flywheelRewards), address(newFlywheelRewards), oldRewardBalance);
         }
 

--- a/src/FlywheelCore.sol
+++ b/src/FlywheelCore.sol
@@ -163,9 +163,11 @@ contract FlywheelCore is Auth {
 
     /// @notice swap out the flywheel rewards contract
     function setFlywheelRewards(IFlywheelRewards newFlywheelRewards) external requiresAuth {
-        uint256 oldRewardBalance = rewardToken.balanceOf(address(flywheelRewards));
-        if (address(flywheelRewards) != address(0) && oldRewardBalance > 0) {
-            rewardToken.safeTransferFrom(address(flywheelRewards), address(newFlywheelRewards), oldRewardBalance);
+        if (address(flywheelRewards) != address(0)) {
+            uint256 oldRewardBalance = rewardToken.balanceOf(address(flywheelRewards));
+
+            if (oldRewardBalance != 0)
+                rewardToken.safeTransferFrom(address(flywheelRewards), address(newFlywheelRewards), oldRewardBalance);
         }
 
         flywheelRewards = newFlywheelRewards;


### PR DESCRIPTION
This PR enables `flywheelRewards` to be initialized with `FlywheelRewards(address(0))` and later updated without concern for its token balances (right now, `setFlywheelRewards` will revert if `FlywheelRewards(address(0))` maintains a non-zero balance of the reward token - e.g. WETH).